### PR TITLE
Fix expansion of 48 to 64 with a negative lower int

### DIFF
--- a/expand48to64random.c
+++ b/expand48to64random.c
@@ -48,14 +48,16 @@ int main(int argc, char** argv) {
   long seed;
   while (scanf("%ld\n", &seed) > 0) {
     long lowerInt = seed & mask_32bit;
-    long upperPartial = (seed >> 32) & mask_16bit;
+    long middle = lowerInt << 16;
+    long offset = (seed & (1L << 31)) >> 31;
+    long upperPartial = ((seed >> 32) + offset) & mask_16bit;
     int i;
     for (i = 0; i < (1 << 16); ++i) {
-      long state = (lowerInt << 16) | i;
+      long state = middle | i;
       long prevState = random_reverse(state);
       long lastOutput = prevState >> 16;
       if ((lastOutput & mask_16bit) == upperPartial) {
-        printf("%ld\n", ((lastOutput << 32) | lowerInt));
+        printf("%ld\n", (((lastOutput - offset) << 32) | lowerInt));
       }
     }
   }


### PR DESCRIPTION
See reasoning here: https://github.com/Badel2/slime_seed_finder/issues/1

Currently it fails 50% of the time and prints out no 64-bit expansion, this PR makes it print out valid 64-bit expansions 100% of the time. On average it outputs 1.226 valid 64-bit expansions per 48-bit input.
